### PR TITLE
Terms url is not used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunaticmuch/docusaurus-dictionary",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunaticmuch/docusaurus-terminology",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A terminology / dictionary add-on for Docusaurus",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ module.exports = function (context, opts) {
       `using default directory "${DEFAULT_OPTIONS.termsDir}"\n`);
   options = Object.assign({}, DEFAULT_OPTIONS, opts);
   validateOptions(options);
-  options.termsUrl = path.join(context.baseUrl, options.termsDir, "/");
+  options.termsUrl = path.join(context.baseUrl, opts.termsUrl, "/");
   options.termsDir = path.resolve(options.termsDir) + "/";
   options.docsDir = path.resolve(options.docsDir) + "/";
   options.glossaryFilepath = path.resolve(options.glossaryFilepath);


### PR DESCRIPTION
As reported in #5 there's an issue with `baseUrl` and `termsUrl`.
This fix should allow now the usage of any `termsUrl`