### PR TITLE
Fix loading files on Windows environments

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -12,7 +12,10 @@ Array.prototype.diff = function(a) {
     return this.filter(function(i) {return a.indexOf(i) < 0;});
 };
 
-async function getFiles(basePath, noParseFiles, noThrow=false) {
+async function getFiles(basePath, noParseFiles, noThrow = false) {
+  // fixes paths on Windows environments, globby requires forward slashes
+  const fixedPath = basePath.replaceAll('\\', '/');
+
   // Added the noThrow optional param
   // in case there is a call to this
   // function that does not want to
@@ -21,7 +24,7 @@ async function getFiles(basePath, noParseFiles, noThrow=false) {
   // get all files under dir
   try {
     // get all md files from basePath
-    files = await globby(basePath+"**/*.{md,mdx}");
+    files = await globby(fixedPath+"**/*.{md,mdx}");
   } catch (err) {
     if (noThrow) {
       // handle error here


### PR DESCRIPTION
Loading files fails on Windows environments (see: https://github.com/LunaticMuch/docusaurus-terminology/issues/9)

Globby requires forward slashes (see: https://github.com/sindresorhus/globby#api), but the path provided to `getFiles` is returned from `path.resolve` with a "/" permanently added to the end. 

This fix will correct any backslashes found in the resulting path into forward slashes.